### PR TITLE
Only declare fog-aws dependency

### DIFF
--- a/lib/s3_uploader.rb
+++ b/lib/s3_uploader.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/aws'
 require 'thread'
 require 'logger'
 require "s3_uploader/version"

--- a/s3_uploader.gemspec
+++ b/s3_uploader.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = S3Uploader::VERSION
   gem.license       = 'MIT'
-  
-  gem.add_dependency 'fog'
-  
+
+  gem.add_dependency 'fog-aws'
+  gem.add_dependency 'mime-types'
+
   gem.add_development_dependency 'rspec', '~>2.14.1'
   gem.add_development_dependency 'rake'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'rspec'
 require 's3_uploader'
 require 'tmpdir'
-require 'fog'
 require 'open3'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Declaring fog as a dependency will include gems for all supported
providers. Since this gem handles S3 uploading specifically, explicitly
require fog-aws.

* State mime-types as an explicit dependency

The tests were failing in master in a clean bundle due to this missing
dependency. Fog::Storage will exit if it is not present.